### PR TITLE
Make DateCase case sensitive

### DIFF
--- a/proselint/DateCase.yml
+++ b/proselint/DateCase.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: With lowercase letters, the periods are standard.
-ignorecase: true
+ignorecase: false
 level: error
 nonword: true
 tokens:


### PR DESCRIPTION
Fixes #5

This rule seems like it should be case sensitive, so this PR changes the `ignorecase` value to `true`.