### PR TITLE
typo: cranded -> craned

### DIFF
--- a/proselint/Nonwords.yml
+++ b/proselint/Nonwords.yml
@@ -11,7 +11,7 @@ swap:
   confirmant: confirmand
   confirmants: confirmands
   conversate: converse
-  crained: cranded
+  crained: craned
   discomforture: discomfort|discomfiture
   dispersement: disbursement|dispersal
   doubtlessly: doubtless|undoubtedly


### PR DESCRIPTION
I presume this is a typo.