### PR TITLE
typo: 'mildy' -> 'mildly'

### DIFF
--- a/proselint/Uncomparables.yml
+++ b/proselint/Uncomparables.yml
@@ -9,7 +9,7 @@ action:
    - ' '
    - '1'
 raw:
-  - \b(?:absolutely|most|more|less|least|very|quite|largely|extremely|increasingly|kind of|mildy|hardly|greatly|sort of)\b\s*
+  - \b(?:absolutely|most|more|less|least|very|quite|largely|extremely|increasingly|kind of|mildly|hardly|greatly|sort of)\b\s*
 tokens:
   - absolute
   - adequate


### PR DESCRIPTION
I'm pretty sure this is a typo.  proselint has it as mildly https://github.com/amperser/proselint/blob/18ecce6409ffd63c6a809e7668edf9e539cec6a2/proselint/checks/uncomparables.py#L64